### PR TITLE
Link to social media guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ e.g. `tweets/2021-04/yt-espresso.tweet`.
 Once the Pull Request is Merged, a Github Action should be triggered which will publish the tweet.
 
 For more information on the tweeting process go [here](tweets/README.md).
+
+## Guidance
+
+Before posting, be sure that tweets adhere to the social media guidelines available in the community repo [here](https://github.com/operate-first/community/blob/main/social-media-guide.md).


### PR DESCRIPTION
This pr updates the readme so that it points out to the new [social media guide](https://github.com/operate-first/community/blob/main/social-media-guide.md). This link will make it easier for the authors of tweets to find and check the guide before posting.